### PR TITLE
Fix to stop tests relying on already downloaded docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ python:
 services:
     - docker
 
-before_install:
-    - docker pull phusion/baseimage
-
 # command to install dependencies
 install:
     - "pip install tox-travis"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+@pytest.fixture(scope="module")
+def pull_docker_image(request):
+    image_name = "phusion/baseimage:latest"
+    from sc import dockercli
+    dockercli.DockerCli("").dcli.pull(image_name)
+    def fin():
+        dockercli.DockerCli("").dcli.remove_image(image_name)
+    request.addfinalizer(fin)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,10 +1,47 @@
+import os
+import stat
 import pytest
 
+from sc import client
+from docker import tls
+
 @pytest.fixture(scope="module")
-def pull_docker_image(request):
+def createClient():
+    myclient = None
+    # Find docker-machine environment variables
+    docker_host = os.getenv("DOCKER_HOST")
+    docker_cert_path = os.getenv("DOCKER_CERT_PATH")
+    docker_machine_name = os.getenv("DOCKER_MACHINE_NAME")
+
+    # Look for linux docker socket file
+    path = "/var/run/docker.sock"
+    isSocket = False
+    if os.path.exists(path):
+        mode = os.stat(path).st_mode
+        isSocket = stat.S_ISSOCK(mode)
+    if isSocket:
+        docker_socket_file ="unix://"+path
+        myclient = client.scClient(base_url=docker_socket_file, version="auto")
+        return myclient
+    elif (docker_host and docker_cert_path and docker_machine_name):
+        tls_config = tls.TLSConfig(
+            client_cert=(os.path.join(docker_cert_path, 'cert.pem'),
+                         os.path.join(docker_cert_path,'key.pem')),
+            ca_cert=os.path.join(docker_cert_path, 'ca.pem'),
+            verify=True,
+            assert_hostname = False
+        )
+        docker_host_https = docker_host.replace("tcp","https")
+        myclient = client.scClient(base_url=docker_host_https, tls=tls_config,
+                                   version="auto")
+        return myclient
+# If we fall through, myclient is set to none and we should fail.
+    return myclient
+
+@pytest.fixture(scope="module")
+def pull_docker_image(request, createClient):
     image_name = "phusion/baseimage:latest"
-    from sc import dockercli
-    dockercli.DockerCli("").dcli.pull(image_name)
+    createClient.pull(image_name)
     def fin():
-        dockercli.DockerCli("").dcli.remove_image(image_name)
+        createClient.remove_image(image_name)
     request.addfinalizer(fin)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,44 +1,6 @@
 import pytest
-import os
-import stat
-from sc import client
-from docker import tls
 import tarfile
 import time
-
-@pytest.fixture
-def createClient():
-    myclient = None
-    # Find docker-machine environment variables
-    docker_host = os.getenv("DOCKER_HOST")
-    docker_cert_path = os.getenv("DOCKER_CERT_PATH")
-    docker_machine_name = os.getenv("DOCKER_MACHINE_NAME")
-
-    # Look for linux docker socket file
-    path = "/var/run/docker.sock"
-    isSocket = False
-    if os.path.exists(path):
-        mode = os.stat(path).st_mode
-        isSocket = stat.S_ISSOCK(mode)
-    if isSocket:
-        docker_socket_file ="unix://"+path
-        myclient = client.scClient(base_url=docker_socket_file, version="auto")
-        return myclient
-    elif (docker_host and docker_cert_path and docker_machine_name):
-        tls_config = tls.TLSConfig(
-            client_cert=(os.path.join(docker_cert_path, 'cert.pem'),
-                         os.path.join(docker_cert_path,'key.pem')),
-            ca_cert=os.path.join(docker_cert_path, 'ca.pem'),
-            verify=True,
-            assert_hostname = False
-        )
-        docker_host_https = docker_host.replace("tcp","https")
-        myclient = client.scClient(base_url=docker_host_https, tls=tls_config,
-                                   version="auto")
-        return myclient
-# If we fall through, myclient is set to none and we should fail.
-    return myclient
-
 
 def test_Client(createClient):
     createClient.info()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -53,7 +53,7 @@ def test_simple_tar(createClient):
     thisfile = createClient.simple_tar('tempprov.txt')
     assert tarfile.is_tarfile(thisfile.name)
 
-def test_hasProv(createClient):
+def test_hasProv(createClient, pull_docker_image):
     # myClient = client.scClient()
     newContainer = createClient.create_container(image='phusion/baseimage', command="/bin/bash", tty=True)
     ContainerID = str(newContainer['Id'])

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -71,13 +71,13 @@ def test_do_command_run():
 
 # Tests function that returns the current image id for
 # "phusion/baseimage"
-def test_get_imageID():
+def test_get_imageID(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
     imageID = dockertester.get_imageID("phusion/baseimage")
     # assert imageID == "e9f50c1887ea"
 
-def test_put_label_image():
+def test_put_label_image(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
     imageID = dockertester.get_imageID("phusion/baseimage")
@@ -85,14 +85,14 @@ def test_put_label_image():
     label = '{"Description":"A containerized foobar","Usage":"docker run --rm example/foobar [args]","License":"GPL","Version":"0.0.1-beta","aBoolean":true,"aNumber":0.01234,"aNestedArray":["a","b","c"]}'
     dockertester.put_label_image(label)
 
-def test_docker_get_metadata():
+def test_docker_get_metadata(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
     imageID = dockertester.get_imageID("phusion/baseimage")
     dockertester.set_image(imageID)
     label = dockertester.get_metadata()
 
-def test_docker_get_label():
+def test_docker_get_label(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
     imageID = dockertester.get_imageID("phusion/baseimage")


### PR DESCRIPTION
Fixes #3 by forcing the tests themselves to download the image
