### PR TITLE
Reduce computational intensity of tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from sc import client
 from docker import tls
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def createClient():
     myclient = None
     # Find docker-machine environment variables
@@ -38,7 +38,7 @@ def createClient():
 # If we fall through, myclient is set to none and we should fail.
     return myclient
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def pull_docker_image(request, createClient):
     image_name = "phusion/baseimage:latest"
     createClient.pull(image_name)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,7 +40,7 @@ def createClient():
 
 @pytest.fixture(scope="session")
 def pull_docker_image(request, createClient):
-    image_name = "phusion/baseimage"
+    image_name = "alpine"
     createClient.pull(image_name+":latest")
     def fin():
         createClient.remove_image(image_name+":latest")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,8 +40,9 @@ def createClient():
 
 @pytest.fixture(scope="session")
 def pull_docker_image(request, createClient):
-    image_name = "phusion/baseimage:latest"
-    createClient.pull(image_name)
+    image_name = "phusion/baseimage"
+    createClient.pull(image_name+":latest")
     def fin():
-        createClient.remove_image(image_name)
+        createClient.remove_image(image_name+":latest")
     request.addfinalizer(fin)
+    return image_name

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,7 +17,7 @@ def test_simple_tar(createClient):
 
 def test_hasProv(createClient, pull_docker_image):
     # myClient = client.scClient()
-    newContainer = createClient.create_container(image='phusion/baseimage', command="/bin/bash", tty=True)
+    newContainer = createClient.create_container(image=pull_docker_image, command="/bin/bash", tty=True)
     ContainerID = str(newContainer['Id'])
     createClient.start(ContainerID)
     #assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,7 +17,7 @@ def test_simple_tar(createClient):
 
 def test_hasProv(createClient, pull_docker_image):
     # myClient = client.scClient()
-    newContainer = createClient.create_container(image=pull_docker_image, command="/bin/bash", tty=True)
+    newContainer = createClient.create_container(image=pull_docker_image, command="/bin/sh", tty=True)
     ContainerID = str(newContainer['Id'])
     createClient.start(ContainerID)
     #assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -74,13 +74,13 @@ def test_do_command_run():
 def test_get_imageID(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID("phusion/baseimage")
+    imageID = dockertester.get_imageID(pull_docker_image)
     # assert imageID == "e9f50c1887ea"
 
 def test_put_label_image(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID("phusion/baseimage")
+    imageID = dockertester.get_imageID(pull_docker_image)
     dockertester.set_image(imageID)
     label = '{"Description":"A containerized foobar","Usage":"docker run --rm example/foobar [args]","License":"GPL","Version":"0.0.1-beta","aBoolean":true,"aNumber":0.01234,"aNestedArray":["a","b","c"]}'
     dockertester.put_label_image(label)
@@ -88,13 +88,13 @@ def test_put_label_image(pull_docker_image):
 def test_docker_get_metadata(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID("phusion/baseimage")
+    imageID = dockertester.get_imageID(pull_docker_image)
     dockertester.set_image(imageID)
     label = dockertester.get_metadata()
 
 def test_docker_get_label(pull_docker_image):
     from sc import dockercli
     dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID("phusion/baseimage")
+    imageID = dockertester.get_imageID(pull_docker_image)
     dockertester.set_image(imageID)
     label = dockertester.get_label()


### PR DESCRIPTION
Reduced the number of times that docker has to download the image for the tests from two to one time and replaced phusion/base with alpine to reduce the download resources required.
