### PR TITLE
Fixing of tests for Client.py

### DIFF
--- a/sc/client.py
+++ b/sc/client.py
@@ -1,17 +1,20 @@
 # Client.py
 
 import docker
+import glob
 import os
 import scMetadata
 import io
 import pprint
+import re
 import tempfile
 import tarfile
 import provinator
 import json
-
+import glob
 
 class scClient(docker.Client):
+
     def __init__(self, *args, **kwargs):
         super(scClient, self).__init__(*args, **kwargs)
 
@@ -86,12 +89,16 @@ class scClient(docker.Client):
     def simple_tar(self, path):
         #Creates temporary tar file from file specified in path.
         # Returns tar file.
+        # t_dir = tempfile.mkdtemp(prefix='app-')
         f = tempfile.NamedTemporaryFile()
-        t = tarfile.open(mode='w', fileobj=f)
+        tar = tarfile.open(mode='w', fileobj=f)
 
         abs_path = os.path.abspath(path)
-        t.add(abs_path, arcname=os.path.basename(path), recursive=False)
+        for filex in glob.glob(abs_path):
+            if filex:
+                archname = re.sub(abs_path,'%s/%s' % (self.provfilepath, path), filex)
+                tar.add(abs_path, arcname=archname, recursive=False)
 
-        t.close()
+        tar.close()
         f.seek(0)
         return f

--- a/sc/client.py
+++ b/sc/client.py
@@ -24,8 +24,7 @@ class scClient(docker.Client):
         self.provfilename = "SCProv.jsonld"
         self.label_prefix = "smartcontainer"
 
-    def commit(self, container, repository=None, tag=None, message=None,
-               author=None, conf=None):
+    def commit(self, container, *args, **kwargs):
         #Extends the docker-py commit command to include smartcontainer functions
         #Check if the container being committed has previous provenance information stored in it.
         if self.hasProv(container,self.provfilename,self.provfilepath):
@@ -38,23 +37,23 @@ class scClient(docker.Client):
             #Remove the local copy of the provenance file
             os.remove(self.provfilename)
             # #Commit the container changes
-            newImage = super(scClient, self).commit(container=container, repository=repository, tag=tag, message=message,
-                         author=author, conf=conf)
+            newImage = super(scClient, self).commit(container=container, *args,
+                                                    **kwargs)
             #Get the ID of the newly created image
             thisID = newImage['Id']
             #Get the label contents in dictionary form.
             newLabel = self.scmd.labelDictionary(self.label_prefix)
             #Write the label to the new image
-            self.put_label_image(thisID, newLabel, repository, tag, message, author, conf)
+            self.put_label_image(thisID, newLabel, *args, **kwargs)
 
         else:
             pass
 
-    def put_label_image(self, imageID, label, repository, tag, message, author, conf):
+    def put_label_image(self, image, label, *args, **kwargs):
         #Write the label to the new image
         #Create a new container with the label, commit it and then remove the container.
-        newContainer = super(scClient, self).create_container(image=imageID, command="/bin/bash", labels=label)
-        super(scClient, self).commit(container=newContainer,repository=repository,tag=tag, message=message, author=author, conf=conf)
+        newContainer = super(scClient, self).create_container(image=image, command="/bin/sh", labels=label)
+        super(scClient, self).commit(container=newContainer, *args, **kwargs)
         super(scClient, self).remove_container(newContainer)
 
     def fileCopyOut(self, containerid, filename, path):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -16,9 +16,9 @@ def test_simple_tar(createClient):
     thisfile = createClient.simple_tar('tempprov.txt')
     assert tarfile.is_tarfile(thisfile.name)
 
-def test_fileCopyIn(createClient,pull_docker_image):
+def test_fileCopyIn(createClient, pull_docker_image):
     newContainer = createClient.create_container(image=pull_docker_image, 
-                                                 command="/bin/bash", tty=True)
+                                                 command="/bin/sh", tty=True)
     ContainerID = str(newContainer['Id'])
     createClient.start(ContainerID)
     with open('SCProv.jsonld', 'a') as provfile:
@@ -30,31 +30,29 @@ def test_fileCopyIn(createClient,pull_docker_image):
     createClient.remove_container(ContainerID)
     os.remove('SCProv.jsonld')
 
-#def test_fileCopyOut(createClient):
-#    newContainer = createClient.create_container(image='phusion/append', command="/bin/bash", tty=True)
-#    ContainerID = str(newContainer['Id'])
-#    createClient.start(ContainerID)
-#    createClient.fileCopyOut(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
-#    assert os.path.isfile('SCProv.jsonld')
-#    time.sleep(1)
-#    createClient.stop(ContainerID)
-#    createClient.remove_container(ContainerID)
-#    os.remove('SCProv.jsonld')
+def test_fileCopyOut(createClient, pull_docker_image):
+    newContainer = createClient.create_container(image=pull_docker_image, command="/bin/sh", tty=True)
+    ContainerID = str(newContainer['Id'])
+    createClient.start(ContainerID)
+    with open('SCProv.jsonld', 'a') as provfile:
+        provfile.write('This is the data for the tar file test.')
+    createClient.fileCopyIn(ContainerID,'SCProv.jsonld','/')
+    createClient.fileCopyOut(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+    assert os.path.isfile('SCProv.jsonld')
+    time.sleep(1)
+    createClient.stop(ContainerID)
+    createClient.remove_container(ContainerID)
+    os.remove('SCProv.jsonld')
 
-#def test_hasProv(createClient, pull_docker_image):
-    # myClient = client.scClient()
-#    newContainer = createClient.create_container(image='phusion/baseimage', command="/bin/bash", tty=True)
-#    ContainerID = str(newContainer['Id'])
-#    createClient.start(ContainerID)
-#    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
-#    time.sleep(1)
-#    createClient.stop(ContainerID)
-#    createClient.remove_container(ContainerID)
 
-#def test_put_label_image(createClient):
-#    myLabel = {'smartcontainer':'{"author":"Scott B. Szakonyi"}'}
-#    createClient.put_label_image(imageID='f7874cea1543', label=myLabel, repository='Test', author=None, conf=None, tag=None, message=None)
-#    myInspect = createClient.inspect_image('Test')
-#    assert 'Szakonyi' in str(myInspect)
-#    createClient.remove_image('Test')
+def test_put_label_image(createClient, pull_docker_image):
+    myLabel = {'smartcontainer':'{"author":"Scott B. Szakonyi"}'}
+    createClient.put_label_image(image=pull_docker_image,
+                                 repository="phusion/baseimage", tag="tester", label=myLabel)
+    # The new image created should be image[0]'s id
+    image_list = createClient.images()
+    image_id = image_list[0]['Id']
+    myInspect = createClient.inspect_image(image_id)
+    assert 'Szakonyi' in str(myInspect)
+    createClient.remove_image(image_id)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -23,8 +23,8 @@ def test_fileCopyIn(createClient,pull_docker_image):
     createClient.start(ContainerID)
     with open('SCProv.jsonld', 'a') as provfile:
         provfile.write('This is the data for the tar file test.')
-    createClient.fileCopyIn(ContainerID,'SCProv.jsonld','/SmartContainer/')
-    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+    createClient.fileCopyIn(ContainerID,'SCProv.jsonld','/')
+    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer')
     time.sleep(1)
     createClient.stop(ContainerID)
     createClient.remove_container(ContainerID)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,6 +1,7 @@
 import pytest
 import tarfile
 import time
+import os
 
 def test_Client(createClient):
     createClient.info()
@@ -15,12 +16,45 @@ def test_simple_tar(createClient):
     thisfile = createClient.simple_tar('tempprov.txt')
     assert tarfile.is_tarfile(thisfile.name)
 
-def test_hasProv(createClient, pull_docker_image):
-    # myClient = client.scClient()
-    newContainer = createClient.create_container(image='phusion/baseimage', command="/bin/bash", tty=True)
+def test_fileCopyIn(createClient,pull_docker_image):
+    newContainer = createClient.create_container(image='phusion/baseimage:latest', 
+                                                 command="/bin/bash", tty=True)
     ContainerID = str(newContainer['Id'])
     createClient.start(ContainerID)
-    #assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+    with open('SCProv.jsonld', 'a') as provfile:
+        provfile.write('This is the data for the tar file test.')
+    createClient.fileCopyIn(ContainerID,'SCProv.jsonld','/SmartContainer/')
+    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
     time.sleep(1)
     createClient.stop(ContainerID)
     createClient.remove_container(ContainerID)
+    os.remove('SCProv.jsonld')
+
+#def test_fileCopyOut(createClient):
+#    newContainer = createClient.create_container(image='phusion/append', command="/bin/bash", tty=True)
+#    ContainerID = str(newContainer['Id'])
+#    createClient.start(ContainerID)
+#    createClient.fileCopyOut(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+#    assert os.path.isfile('SCProv.jsonld')
+#    time.sleep(1)
+#    createClient.stop(ContainerID)
+#    createClient.remove_container(ContainerID)
+#    os.remove('SCProv.jsonld')
+
+#def test_hasProv(createClient, pull_docker_image):
+    # myClient = client.scClient()
+#    newContainer = createClient.create_container(image='phusion/baseimage', command="/bin/bash", tty=True)
+#    ContainerID = str(newContainer['Id'])
+#    createClient.start(ContainerID)
+#    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+#    time.sleep(1)
+#    createClient.stop(ContainerID)
+#    createClient.remove_container(ContainerID)
+
+#def test_put_label_image(createClient):
+#    myLabel = {'smartcontainer':'{"author":"Scott B. Szakonyi"}'}
+#    createClient.put_label_image(imageID='f7874cea1543', label=myLabel, repository='Test', author=None, conf=None, tag=None, message=None)
+#    myInspect = createClient.inspect_image('Test')
+#    assert 'Szakonyi' in str(myInspect)
+#    createClient.remove_image('Test')
+

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,6 +1,7 @@
 import pytest
 import tarfile
 import time
+import os
 
 def test_Client(createClient):
     createClient.info()
@@ -15,12 +16,45 @@ def test_simple_tar(createClient):
     thisfile = createClient.simple_tar('tempprov.txt')
     assert tarfile.is_tarfile(thisfile.name)
 
-def test_hasProv(createClient, pull_docker_image):
-    # myClient = client.scClient()
-    newContainer = createClient.create_container(image=pull_docker_image, command="/bin/sh", tty=True)
+def test_fileCopyIn(createClient,pull_docker_image):
+    newContainer = createClient.create_container(image=pull_docker_image, 
+                                                 command="/bin/bash", tty=True)
     ContainerID = str(newContainer['Id'])
     createClient.start(ContainerID)
-    #assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+    with open('SCProv.jsonld', 'a') as provfile:
+        provfile.write('This is the data for the tar file test.')
+    createClient.fileCopyIn(ContainerID,'SCProv.jsonld','/SmartContainer/')
+    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
     time.sleep(1)
     createClient.stop(ContainerID)
     createClient.remove_container(ContainerID)
+    os.remove('SCProv.jsonld')
+
+#def test_fileCopyOut(createClient):
+#    newContainer = createClient.create_container(image='phusion/append', command="/bin/bash", tty=True)
+#    ContainerID = str(newContainer['Id'])
+#    createClient.start(ContainerID)
+#    createClient.fileCopyOut(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+#    assert os.path.isfile('SCProv.jsonld')
+#    time.sleep(1)
+#    createClient.stop(ContainerID)
+#    createClient.remove_container(ContainerID)
+#    os.remove('SCProv.jsonld')
+
+#def test_hasProv(createClient, pull_docker_image):
+    # myClient = client.scClient()
+#    newContainer = createClient.create_container(image='phusion/baseimage', command="/bin/bash", tty=True)
+#    ContainerID = str(newContainer['Id'])
+#    createClient.start(ContainerID)
+#    assert createClient.hasProv(ContainerID, 'SCProv.jsonld', '/SmartContainer/')
+#    time.sleep(1)
+#    createClient.stop(ContainerID)
+#    createClient.remove_container(ContainerID)
+
+#def test_put_label_image(createClient):
+#    myLabel = {'smartcontainer':'{"author":"Scott B. Szakonyi"}'}
+#    createClient.put_label_image(imageID='f7874cea1543', label=myLabel, repository='Test', author=None, conf=None, tag=None, message=None)
+#    myInspect = createClient.inspect_image('Test')
+#    assert 'Szakonyi' in str(myInspect)
+#    createClient.remove_image('Test')
+


### PR DESCRIPTION
Fixed Client.py API code for:
unit/test_client.py::test_Client
unit/test_client.py::test_simple_tar
unit/test_client.py::test_fileCopyIn
unit/test_client.py::test_fileCopyOut
unit/test_client.py::test_put_label_image
Passes travis-ci tests for Alpine image. Should now work with any image.
