### PR TITLE
Refactoring of dockercli.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ pytz==2015.4
 rdflib==4.2.0
 rdflib-jsonld==0.3
 requests==2.8.1
-sarge==0.1.4
 six==1.9.0
 snowballstemmer==1.2.0
 SPARQLWrapper==1.6.4

--- a/sc/cli.py
+++ b/sc/cli.py
@@ -68,10 +68,12 @@ def search(image):
 
 
 @cli.command()
-@click.argument('printLabel')
-def print_md():
+@click.argument('image')
+def printlabel(image):
     """Print Metadata label from container."""
-    pass
+    processdocker = DockerCli("info") 
+    this_label = processdocker.get_label(image)
+    print this_label
 
 
 @cli.command()
@@ -89,6 +91,13 @@ def preserve():
     """Preserve workflow to container using umbrella."""
     pass
 
+@cli.command()
+@click.argument('image')
+def infect(image):
+    """Provenance should be contagious. Create smartcontainer image from
+    existing image. """
+    processdocker = DockerCli("info")
+    processdocker.infect('image')
 
 #  Orcid Commands  ################################
 #  cwilli34

--- a/sc/client.py
+++ b/sc/client.py
@@ -11,9 +11,10 @@ state change.
 
 import docker
 import glob
+import json
+import re
 import os
 import scMetadata
-import re
 import tempfile
 import tarfile
 
@@ -217,3 +218,44 @@ class scClient(docker.Client):
         super(scClient, self).remove_container(ContainerID)
         newImageID = str(newImage['Id'])
         return newImageID
+
+    def get_label_image(self, imageID):
+        """Get Smart Container Metadata Label from image.
+
+        Args:
+            imageID: Id for image that label is requested
+
+        Returns:
+            metadata: Label String in JSON-LD
+
+        """
+        # Look for the smart container label, if it exists return none
+        myInspect = super(scClient, self).inspect_image(imageID)
+        labels = myInspect['ContainerConfig']['Labels']
+        if labels is not None:
+            # print json.dumps(labels, ensure_ascii=False, sort_keys=True, indent=4,
+            #                 separators=(',', ':')).encode('utf8')
+            return json.dumps(labels)
+        return None
+
+    def get_label_container(self, containerID):
+        """Get Smart Container Metadata Label from a container.
+
+        Args:
+            containerID (TODO): Container ID
+        Returns:
+            metadata: Label String in JSON-LD
+
+        """
+        pass
+
+    def build(self, *args, **kwargs):
+        """TODO: Docstring for build.
+
+        Args:
+            1 (TODO): TODO
+
+        Returns: TODO
+
+        """
+        super(scClient, self).build(*args, **kwargs)

--- a/sc/dockercli.py
+++ b/sc/dockercli.py
@@ -151,12 +151,6 @@ class DockerCli:
             raise DockerNotFoundError("Docker Client cannot find server.")
         # TODO: test for dcli to make sure it can talk to client.
 
-    def get_location(self):
-        """Get path to docker executable.
-        
-        """
-        return self.location
-
     def sanity_check(self):
         """sanity_check checks existence and executability of docker."""
         if self.location is None:
@@ -166,7 +160,16 @@ class DockerCli:
 
     def check_docker_version(self, min_version=min_docker_version):
         """check_docker_version makes sure docker is of a min version."""
-        output = get_stdout('docker --version')
+        # output = get_stdout('docker --version')
+        try:
+            res = subprocess.Popen([self.location, '--version'],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+            output, error = res.communicate()
+        except OSError as e:
+            print "OSError > ", e.errno
+            print "OSError > ", e.strerror
+            print "OSError > ", e.filename
         # in docker 1.7.1 version is at 2 position in returned string
         version = output.split()[2]
         # remove comma from out put if in string

--- a/sc/scMetadata.py
+++ b/sc/scMetadata.py
@@ -1,29 +1,32 @@
-# Metadata functions
+# -*- coding: utf-8 -*-
+"""Smart Containers Metadata Interface.
 
-from sarge import Command, Capture, get_stdout, get_stderr, capture_stdout
+This module provides an interface for the Client to the metadata
+objects that need to writen to a label or inside of a container.
+"""
 import provinator
 import re
 import ast
+
 
 class scMetadata:
     def __init__(self):
         pass
 
     def appendData(self, filepath):
-        #Appends provinator data to the file passed in
+        # Appends provinator data to the file passed in
         with open(filepath, 'a') as provfile:
             provfile.write(provinator.get_commit_data())
 
-    def labelDictionary(self,label_prefix):
-        #Returns the label as a dictionary
-        #Get the label information from provinator
+    def labelDictionary(self, label_prefix):
+        # Returns the label as a dictionary
+        # Get the label information from provinator
         provOutput = provinator.get_commit_label()
-        #Remove any formatting characters
+        # Remove any formatting characters
         provOutput = re.sub('[\t\r\n\s+]', '', provOutput)
-        #Add the label prefix
-        newLabel =  "{'" + label_prefix + "':'" + provOutput + "'}"
-        #Evaluate the string to create the dictionary
+        # Add the label prefix
+        newLabel = "{'" + label_prefix + "':'" + provOutput + "'}"
+        # Evaluate the string to create the dictionary
         newLabel = ast.literal_eval(newLabel)
-        #Return the dictionary
+        # Return the dictionary
         return newLabel
-

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class Tox(TestCommand):
 
 
 
-dependencies = ['click==4.1', 'rdflib', 'rdflib-jsonld', 'sarge', 'orcid',
+dependencies = ['click==4.1', 'rdflib', 'rdflib-jsonld', 'orcid',
                 'orcidfind', 'pyparsing', 'pytz', 'requests==2.7.0', 'docker-py']
 
 setup(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -111,3 +111,14 @@ def test_infect_image(createClient, pull_docker_image):
 def test_infect_container(createClient, pull_docker_image):
     """TODO: Create new Smartcontainer from container ID."""
     pass
+
+
+def test_get_label_image(createClient, pull_docker_image):
+    """Get JSON label from imageID."""
+    imageID = str(createClient.inspect_image(pull_docker_image)['Id'])
+    imageID = imageID.replace('sha256:', '')
+    sc_image = createClient.infect_image(image=imageID)
+    json_str = createClient.get_label_image(imageID=sc_image)
+    assert 'smartcontainer' in str(json_str)
+    # print json_str
+    createClient.remove_image(sc_image)

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -1,14 +1,26 @@
+
+# -*- coding: utf-8 -*-
+"""Tests for Docker Command Line Interface Module.
+
+This module provides the interface to the docker command line utility. Commands
+that need to be processed by smartcontainers are intercepted and sent to
+docker-py client API for processing. All other commands are sent to the docker
+command line client. This is a cheat to avoid having to reimpliment the entire
+docker command line arguments even though only a subset of these commands need
+to be processed for provenance.
+"""
 import pytest
 import os
 from sys import platform as _platform
+
 
 # Test code that discovers docker command
 # This is a bad hack right now
 # The correct way should be monkeypatch fixtures
 # http://holgerkrekel.net/2009/03/03/monkeypatching-in-unit-tests-done-right/
 def test_DockerCli():
+    """Test DockerCli docker initializetion."""
     from sc import dockercli
-   
 
     oldenv = os.environ.copy()
     # Test location first
@@ -16,11 +28,10 @@ def test_DockerCli():
     with pytest.raises(dockercli.DockerNotFoundError):
         # check that exceptions are being raised.
         os.environ["PATH"] = "NULL"
-        dockertester2 = dockercli.DockerCli()
+        dockercli.DockerCli()
     os.environ["PATH"] = oldpath
     # Test environment variables on MacOS
     if _platform == "darwin":
-        docker_host = os.environ["DOCKER_HOST"]
         with pytest.raises(dockercli.DockerNotFoundError):
             os.environ.clear()
             dockertester = dockercli.DockerCli()
@@ -31,25 +42,22 @@ def test_DockerCli():
     dockertester3 = dockercli.DockerCli()
     assert dockertester3.location is not None
 
+
+def test_check_docker_connection():
+    """Test that docker returns something useful."""
+    from sc import dockercli
+    dockertester = dockercli.DockerCli()
+    dockertester.check_docker_connection()
+
+
 def test_docker_version():
+    """Test docker version tester works for an incorrect version."""
     from sc import dockercli
     with pytest.raises(dockercli.DockerInsuficientVersionError):
         # This will fail if docker ever gets to version 100
         dockertester = dockercli.DockerCli()
         dockertester.check_docker_version("100.100.100")
 
-# def test_check_docker_connection():
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli()
-#    if _platform == "darwin":
-#        docker_host = os.environ["DOCKER_HOST"]
-#        with pytest.raises(dockercli.DockerServerError):
-#            os.environ["DOCKER_HOST"] = "tcp://127.0.0.1:1000"
-#            dockertester.check_docker_connection()
-#        os.environ["DOCKER_HOST"] = docker_host
-#        dockertester.check_docker_connection()
-#    else:
-#        dockertester.check_docker_connection()
 
 # Test all sanity checks to make sure docker is there.
 # def test_sanity():

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -6,95 +6,95 @@ from sys import platform as _platform
 # This is a bad hack right now
 # The correct way should be monkeypatch fixtures
 # http://holgerkrekel.net/2009/03/03/monkeypatching-in-unit-tests-done-right/
-def test_find_docker():
+def test_DockerCli():
     from sc import dockercli
+   
+
     oldenv = os.environ.copy()
     # Test location first
     oldpath = os.environ["PATH"]
     with pytest.raises(dockercli.DockerNotFoundError):
-        dockertester = dockercli.DockerCli('help')
         # check that exceptions are being raised.
         os.environ["PATH"] = "NULL"
-        location = dockertester.find_docker()
+        dockertester2 = dockercli.DockerCli()
     os.environ["PATH"] = oldpath
     # Test environment variables on MacOS
     if _platform == "darwin":
         docker_host = os.environ["DOCKER_HOST"]
         with pytest.raises(dockercli.DockerNotFoundError):
             os.environ.clear()
-            dockertester.find_docker()
+            dockertester = dockercli.DockerCli()
         os.environ.update(oldenv)
         dockertester.check_docker_connection()
     if _platform == "linux":
-        dockertester.find_docker()
+        dockertester = dockercli.DockerCli()
+    dockertester3 = dockercli.DockerCli()
+    assert dockertester3.location is not None
 
-    location = dockertester.find_docker()
-    assert location is not None
+# def test_docker_version():
+#     from sc import dockercli
+#    with pytest.raises(dockercli.DockerInsuficientVersionError):
+#        # This will fail if docker ever gets to version 100
+#        dockertester = dockercli.DockerCli()
+#        dockertester.check_docker_version("100.100.100")
 
-def test_docker_version():
-    from sc import dockercli
-    with pytest.raises(dockercli.DockerInsuficientVersionError):
-        # This will fail if docker ever gets to version 100
-        dockertester = dockercli.DockerCli("--help")
-        dockertester.check_docker_version("100.100.100")
-
-def test_check_docker_connection():
-    from sc import dockercli
-    dockertester = dockercli.DockerCli("--help")
-    if _platform == "darwin":
-        docker_host = os.environ["DOCKER_HOST"]
-        with pytest.raises(dockercli.DockerServerError):
-            os.environ["DOCKER_HOST"] = "tcp://127.0.0.1:1000"
-            dockertester.check_docker_connection()
-        os.environ["DOCKER_HOST"] = docker_host
-        dockertester.check_docker_connection()
-    else:
-        dockertester.check_docker_connection()
+# def test_check_docker_connection():
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli()
+#    if _platform == "darwin":
+#        docker_host = os.environ["DOCKER_HOST"]
+#        with pytest.raises(dockercli.DockerServerError):
+#            os.environ["DOCKER_HOST"] = "tcp://127.0.0.1:1000"
+#            dockertester.check_docker_connection()
+#        os.environ["DOCKER_HOST"] = docker_host
+#        dockertester.check_docker_connection()
+#    else:
+#        dockertester.check_docker_connection()
 
 # Test all sanity checks to make sure docker is there.
-def test_sanity():
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('help')
-    dockertester.sanity_check()
+# def test_sanity():
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('help')
+#    dockertester.sanity_check()
 
 # This test should pass through since we don't capture the
 # provenance of help.
-def test_do_command_simple():
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('--help')
-    dockertester.do_command()
+# def test_do_command_simple():
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('--help')
+#    dockertester.do_command()
 
-def test_do_command_run():
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('run /usr/bin/uname')
-    dockertester.do_command()
+# def test_do_command_run():
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('run /usr/bin/uname')
+#    dockertester.do_command()
 
 # Tests function that returns the current image id for
 # "phusion/baseimage"
-def test_get_imageID(pull_docker_image):
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID(pull_docker_image)
-    # assert imageID == "e9f50c1887ea"
+# def test_get_imageID(pull_docker_image):
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('images')
+#    imageID = dockertester.get_imageID(pull_docker_image)
+#    # assert imageID == "e9f50c1887ea"
 
-def test_put_label_image(pull_docker_image):
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID(pull_docker_image)
-    dockertester.set_image(imageID)
-    label = '{"Description":"A containerized foobar","Usage":"docker run --rm example/foobar [args]","License":"GPL","Version":"0.0.1-beta","aBoolean":true,"aNumber":0.01234,"aNestedArray":["a","b","c"]}'
-    dockertester.put_label_image(label)
+# def test_put_label_image(pull_docker_image):
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('images')
+#    imageID = dockertester.get_imageID(pull_docker_image)
+#    dockertester.set_image(imageID)
+#    label = '{"Description":"A containerized foobar","Usage":"docker run --rm example/foobar [args]","License":"GPL","Version":"0.0.1-beta","aBoolean":true,"aNumber":0.01234,"aNestedArray":["a","b","c"]}'
+#    dockertester.put_label_image(label)
 
-def test_docker_get_metadata(pull_docker_image):
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID(pull_docker_image)
-    dockertester.set_image(imageID)
-    label = dockertester.get_metadata()
+# def test_docker_get_metadata(pull_docker_image):
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('images')
+#    imageID = dockertester.get_imageID(pull_docker_image)
+#    dockertester.set_image(imageID)
+#    label = dockertester.get_metadata()
 
-def test_docker_get_label(pull_docker_image):
-    from sc import dockercli
-    dockertester = dockercli.DockerCli('images')
-    imageID = dockertester.get_imageID(pull_docker_image)
-    dockertester.set_image(imageID)
-    label = dockertester.get_label()
+# def test_docker_get_label(pull_docker_image):
+#    from sc import dockercli
+#    dockertester = dockercli.DockerCli('images')
+#    imageID = dockertester.get_imageID(pull_docker_image)
+#    dockertester.set_image(imageID)
+#    #label = dockertester.get_label(imageID)

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -59,50 +59,33 @@ def test_docker_version():
         dockertester.check_docker_version("100.100.100")
 
 
-# Test all sanity checks to make sure docker is there.
-# def test_sanity():
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli('help')
-#    dockertester.sanity_check()
-
 # This test should pass through since we don't capture the
 # provenance of help.
-# def test_do_command_simple():
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli('--help')
-#    dockertester.do_command()
+def test_do_command_simple():
+    """Test simple docker command to pass through."""
+    from sc import dockercli
+    dockertester = dockercli.DockerCli()
+    dockertester.do_command('--help')
+
+
+def test_do_command_commit(createClient, pull_docker_image):
+    """TODO: Docstring for test_do_command_commit.
+
+    Returns: TODO
+
+    """
+    from sc import dockercli
+    dockertester = dockercli.DockerCli()
+    newContainer = createClient.create_container(image=pull_docker_image,
+                                                 command="/bin/sh", tty=True)
+    ContainerID = str(newContainer['Id'])
+    createClient.start(ContainerID)
+    cmd_str = 'commit ' + ContainerID
+    dockertester.do_command(cmd_str)
+    createClient.stop(ContainerID)
+    createClient.remove_container(ContainerID)
 
 # def test_do_command_run():
 #    from sc import dockercli
 #    dockertester = dockercli.DockerCli('run /usr/bin/uname')
 #    dockertester.do_command()
-
-# Tests function that returns the current image id for
-# "phusion/baseimage"
-# def test_get_imageID(pull_docker_image):
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli('images')
-#    imageID = dockertester.get_imageID(pull_docker_image)
-#    # assert imageID == "e9f50c1887ea"
-
-# def test_put_label_image(pull_docker_image):
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli('images')
-#    imageID = dockertester.get_imageID(pull_docker_image)
-#    dockertester.set_image(imageID)
-#    label = '{"Description":"A containerized foobar","Usage":"docker run --rm example/foobar [args]","License":"GPL","Version":"0.0.1-beta","aBoolean":true,"aNumber":0.01234,"aNestedArray":["a","b","c"]}'
-#    dockertester.put_label_image(label)
-
-# def test_docker_get_metadata(pull_docker_image):
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli('images')
-#    imageID = dockertester.get_imageID(pull_docker_image)
-#    dockertester.set_image(imageID)
-#    label = dockertester.get_metadata()
-
-# def test_docker_get_label(pull_docker_image):
-#    from sc import dockercli
-#    dockertester = dockercli.DockerCli('images')
-#    imageID = dockertester.get_imageID(pull_docker_image)
-#    dockertester.set_image(imageID)
-#    #label = dockertester.get_label(imageID)

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -31,12 +31,12 @@ def test_DockerCli():
     dockertester3 = dockercli.DockerCli()
     assert dockertester3.location is not None
 
-# def test_docker_version():
-#     from sc import dockercli
-#    with pytest.raises(dockercli.DockerInsuficientVersionError):
-#        # This will fail if docker ever gets to version 100
-#        dockertester = dockercli.DockerCli()
-#        dockertester.check_docker_version("100.100.100")
+def test_docker_version():
+    from sc import dockercli
+    with pytest.raises(dockercli.DockerInsuficientVersionError):
+        # This will fail if docker ever gets to version 100
+        dockertester = dockercli.DockerCli()
+        dockertester.check_docker_version("100.100.100")
 
 # def test_check_docker_connection():
 #    from sc import dockercli

--- a/tests/unit/test_dockercli.py
+++ b/tests/unit/test_dockercli.py
@@ -34,11 +34,11 @@ def test_DockerCli():
     if _platform == "darwin":
         with pytest.raises(dockercli.DockerNotFoundError):
             os.environ.clear()
-            dockertester = dockercli.DockerCli()
+            dockercli.DockerCli()
         os.environ.update(oldenv)
-        dockertester.check_docker_connection()
+        # dockertester.check_docker_connection()
     if _platform == "linux":
-        dockertester = dockercli.DockerCli()
+        dockercli.DockerCli()
     dockertester3 = dockercli.DockerCli()
     assert dockertester3.location is not None
 


### PR DESCRIPTION
Refactored dockercli to reflect that it now only provides an interface to the command line docker utility and will handle tokenizing arguments for docker commands to be passed to the docker-py client interface.
